### PR TITLE
add self-hosted to Github Actions configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   yocto-aarch64:
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, ubuntu-24.04]
     container:
     steps:
       - name: Packages
@@ -38,7 +38,7 @@ jobs:
           bitbake swift-hello-world
 
   yocto-armv7:
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, ubuntu-24.04]
     container:
     steps:
       - name: Packages
@@ -69,7 +69,7 @@ jobs:
           bitbake swift-hello-world
 
   yocto-x86_64:
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, ubuntu-24.04]
     container:
     steps:
       - name: Packages


### PR DESCRIPTION
By adding `self-hosted` to the Github Actions configuration,
it enables us to run the Github Actions on our own hardware.
While a token(authentication) is required to trigger the job from this repository, using a fork of this repository the developer is able to generate a token and start a self hosted job.