### PR TITLE
re-enable 64-bit timestamps on 32-bit targets

### DIFF
--- a/classes/swift-target-tune.bbclass
+++ b/classes/swift-target-tune.bbclass
@@ -1,8 +1,3 @@
-# force disable GLIBC_64BIT_TIME_FLAGS until SwiftNIO and other common packages
-# are updated to support 64-bit time_t on 32-bit systems. ABI incompatibility
-# may cause your program to crash; you have been warned.
-TARGET_CC_ARCH:remove:arm = "${GLIBC_64BIT_TIME_FLAGS}"
-
 # appears to cause segfault
 TARGET_CC_ARCH:remove:aarch64 = "-mbranch-protection=standard"
 


### PR DESCRIPTION
The release of SwiftNIO 2.84.0 allows 64-bit timestamps on 32-bit targets (such as armv7) to be re-enabled with some confidence.

This can be re-disabled in local configuration by setting TARGET_CC_ARCH:remove to "${GLIBC_64BIT_TIME_FLAGS}".