### PR TITLE
Github configuration: use ternary operator to decide upon self hosted

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,16 @@
 name: build
-
 on:
   push:
   pull_request:
   workflow_dispatch:
+    inputs:
+      is_self_hosted:
+        type: boolean
+        default: false
 
 jobs:
   yocto-aarch64:
-    runs-on: [self-hosted, ubuntu-24.04]
+    runs-on: ${{ inputs.is_self_hosted && 'self-hosted' || 'ubuntu-24.04' }}
     container:
     steps:
       - name: Packages
@@ -38,7 +41,7 @@ jobs:
           bitbake swift-hello-world
 
   yocto-armv7:
-    runs-on: [self-hosted, ubuntu-24.04]
+    runs-on: ${{ inputs.is_self_hosted && 'self-hosted' || 'ubuntu-24.04' }}
     container:
     steps:
       - name: Packages
@@ -69,7 +72,7 @@ jobs:
           bitbake swift-hello-world
 
   yocto-x86_64:
-    runs-on: [self-hosted, ubuntu-24.04]
+    runs-on: ${{ inputs.is_self_hosted && 'self-hosted' || 'ubuntu-24.04' }}
     container:
     steps:
       - name: Packages


### PR DESCRIPTION
With #21 self-hosted was introduced.
However with this configuration, the jobs running on Github's CI stay queued and never start running.
This PR solves this by using a ternary operator, which is false by default and for self-hosted use simply can be enabled by eg. adding it to curl -d:
```
curl -L \
  -X POST \
  -H "Accept: application/vnd.github+json" \
  -H "Authorization: Bearer $TOKEN" \
  -H "X-GitHub-Api-Version: 2022-11-28" \
  "$REPOSITORY_API_URL/actions/workflows/build.yml/dispatches" \
   -d "{\"ref\":\"$1\", \"inputs\":{\"is_self_hosted\":\"true\"}}"
```