### PR TITLE
don't build with -mthumb on armv7

### DIFF
--- a/classes/swift-target-tune.bbclass
+++ b/classes/swift-target-tune.bbclass
@@ -1,5 +1,6 @@
 # appears to cause segfault
 TARGET_CC_ARCH:remove:aarch64 = "-mbranch-protection=standard"
+TARGET_CC_ARCH:remove:arm = "-mthumb"
 
 # workaround for building on x86_64: SSE appears to cause cyclic header
 # dependency when building C++ std module. This needs investigation and an


### PR DESCRIPTION
Using thumb instructions appears to cause Swift executables to segfault.

Fixes: #39