### PR TITLE
#51: Add fix for -mthumb runtime crash, re-enable -mthumb if Yocto provides it

### DIFF
--- a/classes/swift-target-tune.bbclass
+++ b/classes/swift-target-tune.bbclass
@@ -1,6 +1,5 @@
 # appears to cause segfault
 TARGET_CC_ARCH:remove:aarch64 = "-mbranch-protection=standard"
-TARGET_CC_ARCH:remove:arm = "-mthumb"
 
 # workaround for building on x86_64: SSE appears to cause cyclic header
 # dependency when building C++ std module. This needs investigation and an

--- a/recipes-devtools/swift/swift-stdlib.bb
+++ b/recipes-devtools/swift/swift-stdlib.bb
@@ -19,6 +19,7 @@ SRC_URI = "\
     git://github.com/swiftlang/swift-syntax.git;protocol=https;name=syntax;tag=${SWIFT_TAG};nobranch=1;destsuffix=swift-syntax; \
     file://0001-add-arm-to-float16support-for-armv7.patch;striplevel=1; \
     file://0002-build-with-64-bit-time_t-on-32-bit-platforms.patch;striplevel=1; \
+    file://0003-add-fix-for-metadataaccessor-abi-mismatch.patch;striplevel=1; \
     "
 
 S = "${UNPACKDIR}/swift"

--- a/recipes-devtools/swift/swift-stdlib/0003-add-fix-for-metadataaccessor-abi-mismatch.patch
+++ b/recipes-devtools/swift/swift-stdlib/0003-add-fix-for-metadataaccessor-abi-mismatch.patch
@@ -1,0 +1,29 @@
+From 65a869926fae8d8e9eeaa6cf42b77d279caa3b70 Mon Sep 17 00:00:00 2001
+From: "Jesse L. Zamora" <xtremekforever@gmail.com>
+Date: Thu, 19 Mar 2026 00:52:46 +0000
+Subject: [PATCH] Add fix for MetadataAccessor ABI mismatch
+
+Upstream-Status: Backport
+---
+ include/swift/ABI/Metadata.h | 5 +++--
+ 1 file changed, 3 insertions(+), 2 deletions(-)
+
+diff --git a/include/swift/ABI/Metadata.h b/include/swift/ABI/Metadata.h
+index bede8490591..a972b99f431 100644
+--- a/include/swift/ABI/Metadata.h
++++ b/include/swift/ABI/Metadata.h
+@@ -4297,8 +4297,9 @@ public:
+     TargetCanonicalSpecializedMetadatasListCount<Runtime>;
+   using MetadataListEntry = 
+     TargetCanonicalSpecializedMetadatasListEntry<Runtime>;
+-  using MetadataAccessor = 
+-    TargetCompactFunctionPointer<Runtime, MetadataResponse(MetadataRequest), /*Nullable*/ false>;
++  using MetadataAccessor = TargetCompactFunctionPointer<
++      Runtime, SWIFT_CC(swift) MetadataResponse(MetadataRequest),
++      /*Nullable*/ false>;
+   using MetadataAccessorListEntry =
+       TargetCanonicalSpecializedMetadataAccessorsListEntry<Runtime>;
+   using MetadataCachingOnceToken =
+-- 
+2.43.0
+


### PR DESCRIPTION
This appears to work fine with qemuarm. I've been testing -mthumb on both the Raspberry Pi as well as with my company's Yocto distro and it seems to be working well. We will probably switch our 6.2.4 build to using it by default to save space.