### PR TITLE
Use libcurl.so.4 from native sysroot when resolving/compiling Swift packages

### DIFF
--- a/classes/swift.bbclass
+++ b/classes/swift.bbclass
@@ -68,6 +68,15 @@ python do_swift_package_resolve() {
 
     env = os.environ.copy()
 
+    # Prefer curl-native over the host's libcurl: the prebuilt swift-native's
+    # libFoundationNetworking (e.g. from amazonlinux2) is linked against a
+    # specific libcurl.so.4 and aborts loading an incompatible host libcurl
+    # (issue #42).
+    ld_path = f'{recipe_sysroot_native}/usr/lib'
+    if env.get('LD_LIBRARY_PATH'):
+        ld_path += ':' + env['LD_LIBRARY_PATH']
+    env['LD_LIBRARY_PATH'] = ld_path
+
     ssh_auth_sock = d.getVar('BB_ORIGENV').get('SSH_AUTH_SOCK')
     if ssh_auth_sock:
         env['SSH_AUTH_SOCK'] = ssh_auth_sock
@@ -342,6 +351,16 @@ python swift_do_compile() {
     recipe_sysroot_native = d.getVar("STAGING_DIR_NATIVE", True)
 
     env = os.environ.copy()
+
+    # Prefer curl-native over the host's libcurl: the prebuilt swift-native's
+    # libFoundationNetworking (e.g. from amazonlinux2) is linked against a
+    # specific libcurl.so.4 and aborts loading an incompatible host libcurl
+    # (issue #42).
+    ld_path = f'{recipe_sysroot_native}/usr/lib'
+    if env.get('LD_LIBRARY_PATH'):
+        ld_path += ':' + env['LD_LIBRARY_PATH']
+    env['LD_LIBRARY_PATH'] = ld_path
+
     if ssh_auth_sock:
         env['SSH_AUTH_SOCK'] = ssh_auth_sock
     env['SYSROOT'] = recipe_sysroot


### PR DESCRIPTION
This should fix the crash on Ubuntu 22.04 when compiling swift-testing. @xavgru12 can you please test this branch on your end and conform? 