### PR TITLE
Rework meta-swift to be multilib-aware

### DIFF
--- a/classes/swift-cmake-base.bbclass
+++ b/classes/swift-cmake-base.bbclass
@@ -47,8 +47,8 @@ OECMAKE_C_COMPILER = "clang"
 OECMAKE_CXX_COMPILER = "clang++"
 
 # Point clang to where the C++ runtime is for our target arch
-RUNTIME_FLAGS = "${TARGET_CC_ARCH} -w -fuse-ld=lld -B${STAGING_DIR_TARGET}/usr/lib/${TARGET_SYS}/${SWIFT_GCC_VERSION}"
-TARGET_LDFLAGS:append = " ${TARGET_LD_ARCH} -L${STAGING_DIR_TARGET}/usr/lib/${TARGET_SYS}/${SWIFT_GCC_VERSION}"
+RUNTIME_FLAGS = "${TARGET_CC_ARCH} -w -fuse-ld=lld -B${STAGING_DIR_TARGET}/${libdir}/${TARGET_SYS}/${SWIFT_GCC_VERSION}"
+TARGET_LDFLAGS:append = " ${TARGET_LD_ARCH} -L${STAGING_DIR_TARGET}/${libdir}/${TARGET_SYS}/${SWIFT_GCC_VERSION}"
 
 # Remove unsupported linker flags
 TARGET_LDFLAGS:remove = "-Wl,-O1"
@@ -76,27 +76,34 @@ EXTRA_OECMAKE:append = " -DLLVM_BUILD_LIBRARY_DIR=${HOST_LLVM_PATH}"
 EXTRA_SWIFTC_FLAGS ??= ""
 
 SWIFT_FLAGS = "-target ${SWIFT_TARGET_NAME} -use-ld=lld \
-    -resource-dir ${STAGING_DIR_TARGET}/usr/lib/swift \
+    -resource-dir ${STAGING_DIR_TARGET}/${libdir}/swift \
     -module-cache-path ${B}/${BUILD_MODE}/ModuleCache \
-    -Xclang-linker -B${STAGING_DIR_TARGET}/usr/lib \
-    -Xclang-linker -B${STAGING_DIR_TARGET}/usr/lib/${TARGET_SYS}/${SWIFT_GCC_VERSION} \
+    -Xclang-linker -B${STAGING_DIR_TARGET}/${libdir} \
+    -Xclang-linker -B${STAGING_DIR_TARGET}/${libdir}/${TARGET_SYS}/${SWIFT_GCC_VERSION} \
     ${SWIFT_EXTRA_SWIFTC_CC_FLAGS} \
-    -I${STAGING_DIR_NATIVE}/usr/lib/${TARGET_SYS}/gcc/${TARGET_SYS}/${SWIFT_GCC_VERSION}/include \
-    -I${STAGING_DIR_NATIVE}/usr/lib/${TARGET_SYS}/gcc/${TARGET_SYS}/${SWIFT_GCC_VERSION}/include-fixed \
-    -I${STAGING_DIR_NATIVE}/usr/lib/clang/${SWIFT_CLANG_VERSION}/include \
-    -I${STAGING_DIR_NATIVE}/usr/lib/clang/${SWIFT_CLANG_VERSION}/include-fixed \
-    -Xcc -I${STAGING_DIR_NATIVE}/usr/lib/${TARGET_SYS}/gcc/${TARGET_SYS}/${SWIFT_GCC_VERSION}/include \
-    -Xcc -I${STAGING_DIR_NATIVE}/usr/lib/${TARGET_SYS}/gcc/${TARGET_SYS}/${SWIFT_GCC_VERSION}/include-fixed \
-    -Xcc -I${STAGING_DIR_NATIVE}/usr/lib/clang/${SWIFT_CLANG_VERSION}/include \
-    -Xcc -I${STAGING_DIR_NATIVE}/usr/lib/clang/${SWIFT_CLANG_VERSION}/include-fixed \
+    -I${STAGING_DIR_NATIVE}/${libdir_native}/${TARGET_SYS}/gcc/${TARGET_SYS}/${SWIFT_GCC_VERSION}/include \
+    -I${STAGING_DIR_NATIVE}/${libdir_native}/${TARGET_SYS}/gcc/${TARGET_SYS}/${SWIFT_GCC_VERSION}/include-fixed \
+    -I${STAGING_DIR_NATIVE}/${libdir_native}/clang/${SWIFT_CLANG_VERSION}/include \
+    -I${STAGING_DIR_NATIVE}/${libdir_native}/clang/${SWIFT_CLANG_VERSION}/include-fixed \
+    -Xcc -I${STAGING_DIR_NATIVE}/${libdir_native}/${TARGET_SYS}/gcc/${TARGET_SYS}/${SWIFT_GCC_VERSION}/include \
+    -Xcc -I${STAGING_DIR_NATIVE}/${libdir_native}/${TARGET_SYS}/gcc/${TARGET_SYS}/${SWIFT_GCC_VERSION}/include-fixed \
+    -Xcc -I${STAGING_DIR_NATIVE}/${libdir_native}/clang/${SWIFT_CLANG_VERSION}/include \
+    -Xcc -I${STAGING_DIR_NATIVE}/${libdir_native}/clang/${SWIFT_CLANG_VERSION}/include-fixed \
     -L${STAGING_DIR_TARGET} \
-    -L${STAGING_DIR_TARGET}/lib \
-    -L${STAGING_DIR_TARGET}/usr/lib \
-    -L${STAGING_DIR_TARGET}/usr/lib/swift \
-    -L${STAGING_DIR_TARGET}/usr/lib/swift/linux \
-    -L${STAGING_DIR_TARGET}/usr/lib/${TARGET_SYS}/${SWIFT_GCC_VERSION} \
+    -L${STAGING_DIR_TARGET}/${libdir} \
+    -L${STAGING_DIR_TARGET}/${libdir}/swift \
+    -L${STAGING_DIR_TARGET}/${libdir}/swift/linux \
+    -L${STAGING_DIR_TARGET}/${libdir}/${TARGET_SYS}/${SWIFT_GCC_VERSION} \
     -sdk ${STAGING_DIR_TARGET} \
     ${EXTRA_SWIFTC_FLAGS} \
 "
 
-HOST_LLVM_PATH = "${STAGING_DIR_NATIVE}/usr/lib"
+HOST_LLVM_PATH = "${STAGING_DIR_NATIVE}/${libdir_native}"
+
+do_configure:prepend() {
+    swift_multilib_prepare_sysroot
+}
+
+do_install:append() {
+    swift_multilib_install_fixup
+}

--- a/classes/swift-cmake.bbclass
+++ b/classes/swift-cmake.bbclass
@@ -2,4 +2,4 @@ inherit swift-cmake-base
 
 DEPENDS:append = " swift-stdlib libdispatch swift-foundation"
 
-TARGET_LDFLAGS += "-L${STAGING_DIR_TARGET}/usr/lib/swift/linux"
+TARGET_LDFLAGS += "-L${STAGING_DIR_TARGET}/${libdir}/swift/linux"

--- a/classes/swift-common.bbclass
+++ b/classes/swift-common.bbclass
@@ -21,23 +21,31 @@ python () {
 
 SWIFT_CLANG_VERSION = "21"
 
-# Use Yocto's TARGET_SYS instead of the upstream Swift triple, so swiftc -target,
-# .swiftinterface module names and clang's per-triple header lookup all agree.
+# Swift's LLVM triple parser silently normalises any Yocto triple (e.g.
+# aarch64-poky-linux, armv7-poky-linux-gnueabihf) down to the LLVM-canonical
+# <arch>-unknown-linux-<env> when it writes the per-target .swiftmodule /
+# .swiftinterface files inside a merged .swiftmodule directory. If we told
+# downstream swiftc invocations to look under the Yocto triple, the stdlib's
+# files would only be reachable under the LLVM-canonical name and swiftc
+# rejects the "close match" with e.g. "could not find module 'Swift' for
+# target 'aarch64-poky-linux'; found: aarch64-unknown-linux-gnu". Force the
+# LLVM-canonical triple here so the -target we pass and the filename the
+# stdlib actually emitted agree.
 #
-# On 32-bit arm, TARGET_SYS is e.g. arm-oe-linux-gnueabi, which is wrong for
-# swiftc's -target in two ways. First, the bare "arm" arch token isn't a
-# platform swiftc recognises, so it warns "unknown platform, assuming
+# On 32-bit arm, TARGET_ARCH is the bare "arm" token, which swiftc doesn't
+# recognise as a platform (it warns "unknown platform, assuming
 # -mfloat-abi=soft" and looks for the per-arch SwiftGlibc modulemap under an
-# "arm" dir while the stdlib stages it under "armv7" (SWIFT_TARGET_ARCH), so the
-# build dies with "error: no such module 'SwiftGlibc'". Second, Yocto keeps the
-# float ABI out of the triple and conveys hard-float via -mfloat-abi=hard in
-# TARGET_CC_ARCH. Those flags only reach the Clang importer via -Xcc, but
-# swiftc's own codegen takes the float ABI from the triple, so a gnueabi triple
-# is soft-float against a hard-float (cortexa15t2hf) sysroot. Promote the arch
-# token to armv7 and append the "hf" environment suffix, keeping Yocto's
-# vendor/os so .swiftinterface module names still agree. aarch64 and x86_64 have
-# no such ambiguity and use TARGET_SYS verbatim.
-SWIFT_TARGET_NAME = "${@oe.utils.conditional('TARGET_ARCH', 'arm', d.getVar('TARGET_SYS').replace('arm-', 'armv7-', 1) + 'hf', '${TARGET_SYS}', d)}"
+# "arm" dir while the stdlib stages it under "armv7" - SWIFT_TARGET_ARCH).
+# Yocto keeps the float ABI out of TARGET_SYS itself and instead conveys it
+# via -mfloat-abi=hard in TARGET_CC_ARCH. That -Xcc flag only reaches the
+# Clang importer, but swiftc's own codegen takes the float ABI from the
+# triple, so a bare gnueabi triple would be soft-float against a hard-float
+# (e.g. cortexa15t2hf) sysroot. Promote the arch token to armv7 and pick the
+# eabi environment from ARMPKGSFX_EABI, which Yocto's feature-arm-vfp.inc
+# already sets to "hf" when callconvention-hard is in TUNE_FEATURES and to
+# "" otherwise, so hardfloat and softfloat ARM tunes each get the triple
+# that matches how the stdlib was actually built.
+SWIFT_TARGET_NAME = "${@oe.utils.conditional('TARGET_ARCH', 'arm', 'armv7-unknown-linux-gnueabi${ARMPKGSFX_EABI}', '${TARGET_ARCH}-unknown-linux-gnu', d)}"
 SWIFT_TARGET_ARCH = "${@oe.utils.conditional('TARGET_ARCH', 'arm', 'armv7', '${TARGET_ARCH}', d)}"
 TARGET_CPU_NAME = "${@oe.utils.conditional('TARGET_ARCH', 'arm', 'armv7-a', '${TARGET_ARCH}', d)}"
 

--- a/classes/swift-common.bbclass
+++ b/classes/swift-common.bbclass
@@ -51,4 +51,51 @@ TARGET_CPU_NAME = "${@oe.utils.conditional('TARGET_ARCH', 'arm', 'armv7-a', '${T
 
 BUILD_MODE = "${@['release', 'debug'][d.getVar('DEBUG_BUILD') == '1']}"
 
+# True when building a multilib image with 64-bit target userspace (lib32 present
+# for 32-bit compat only). Swift target packages are 64-bit only in this mode.
+MULTILIB_BUILD = "${@bb.utils.contains('MULTILIBS', 'multilib:lib32', 'true', 'false', d)}"
+
+swift_multilib_prepare_sysroot() {
+    if [ "${MULTILIB_BUILD}" != "true" ]; then
+        return
+    fi
+
+    # Swift/CMake hard-code /usr/lib/swift. On multilib aarch64 the runtime is
+    # under usr/${baselib}/swift, while usr/lib already exists as a real dir.
+    # yocto uses ${libdir} to refer to usr/${baselib} and ${libdir_native} to refer to /usr/lib.
+    swift_src="${STAGING_DIR_TARGET}/${libdir}/swift"
+    lib_swift="${STAGING_DIR_TARGET}/${libdir_native}/swift"
+    if [ -d "${swift_src}" ]; then
+        mkdir -p "${STAGING_DIR_TARGET}/${libdir_native}"
+        rm -rf "${lib_swift}"
+        ln -sf "../${baselib}/swift" "${lib_swift}"
+    elif [ ! -e "${STAGING_DIR_TARGET}/${libdir_native}" ]; then
+        ln -s "${baselib}" "${STAGING_DIR_TARGET}/${libdir_native}"
+    fi
+
+    # Linker isn't finding crtbeginS.o and crtendS.o under ${TARGET_SYS} path.
+    if [ -d "${STAGING_DIR_TARGET}/${libdir}/${TARGET_SYS}" ]; then
+        cp -r ${STAGING_DIR_TARGET}/${libdir}/${TARGET_SYS}/*/* ${STAGING_DIR_TARGET}/${libdir}/ 2>/dev/null || true
+    fi
+}
+
+swift_multilib_install_fixup() {
+    if [ "${MULTILIB_BUILD}" != "true" ]; then
+        return
+    fi
+
+    if [ ! -d "${D}/${libdir_native}" ]; then
+        return
+    fi
+
+    # CMake/Swift often install under hard-coded usr/lib while other artifacts
+    # land in usr/${baselib}; merge so FILES:${PN} paths match ${libdir}.
+    if [ ! -d "${D}/${libdir}" ]; then
+        mv "${D}/${libdir_native}" "${D}/${libdir}"
+    else
+        cp -a "${D}/${libdir_native}/." "${D}/${libdir}/"
+        rm -rf "${D}/${libdir_native}"
+    fi
+}
+
 inherit swift-target-tune

--- a/classes/swift.bbclass
+++ b/classes/swift.bbclass
@@ -32,7 +32,7 @@ SWIFT_GIT_SSH_COMMAND ?= "env -u LD_LIBRARY_PATH ssh"
 do_fix_gcc_install_dir() {
     # symbolic links do not work, will not be found by Swift clang driver
     # this is necessary to make the libstdc++ location heuristic work, necessary for C++ interop
-    (cd ${STAGING_DIR_TARGET}/usr/lib && rm -rf gcc && mkdir -p gcc && cp -rp ${TARGET_ARCH}${TARGET_VENDOR}-${TARGET_OS} gcc)
+    (cd ${STAGING_DIR_TARGET}/${libdir} && rm -rf gcc && mkdir -p gcc && cp -rp ${TARGET_ARCH}${TARGET_VENDOR}-${TARGET_OS} gcc)
 }
 
 addtask fix_gcc_install_dir before do_configure after do_prepare_recipe_sysroot
@@ -152,8 +152,8 @@ python swift_do_configure() {
             "-I${STAGING_INCDIR}",
             "-I${STAGING_DIR_TARGET}/usr/include/c++/${SWIFT_GCC_VERSION}",
             "-I${STAGING_DIR_TARGET}/usr/include/c++/${SWIFT_GCC_VERSION}/${TARGET_SYS}",
-            "-I${STAGING_DIR_NATIVE}/usr/lib/clang/${SWIFT_CLANG_VERSION}/include",
-            "-I${STAGING_DIR_NATIVE}/usr/lib/clang/${SWIFT_CLANG_VERSION}/include-fixed"
+            "-I${STAGING_DIR_NATIVE}/${libdir_native}/clang/${SWIFT_CLANG_VERSION}/include",
+            "-I${STAGING_DIR_NATIVE}/${libdir_native}/clang/${SWIFT_CLANG_VERSION}/include-fixed"
         ],
         "extra-swiftc-flags":[
             "-target", "${SWIFT_TARGET_NAME}",
@@ -161,30 +161,29 @@ python swift_do_configure() {
             "-tools-directory", "${STAGING_DIR_NATIVE}/usr/bin",
 
             "-enforce-exclusivity=unchecked",
-            "-resource-dir", "${STAGING_DIR_TARGET}/usr/lib/swift",
+            "-resource-dir", "${STAGING_DIR_TARGET}/${libdir}/swift",
             "-module-cache-path", "${B}/${BUILD_MODE}/ModuleCache",
             "-sdk", "${STAGING_DIR_TARGET}",
 
             "-I${STAGING_INCDIR}",
             "-I${STAGING_DIR_TARGET}/usr/include/c++/${SWIFT_GCC_VERSION}",
             "-I${STAGING_DIR_TARGET}/usr/include/c++/${SWIFT_GCC_VERSION}/${TARGET_SYS}",
-            "-I${STAGING_DIR_NATIVE}/usr/lib/clang/${SWIFT_CLANG_VERSION}/include",
-            "-I${STAGING_DIR_NATIVE}/usr/lib/clang/${SWIFT_CLANG_VERSION}/include-fixed",
+            "-I${STAGING_DIR_NATIVE}/${libdir_native}/clang/${SWIFT_CLANG_VERSION}/include",
+            "-I${STAGING_DIR_NATIVE}/${libdir_native}/clang/${SWIFT_CLANG_VERSION}/include-fixed",
 
-            "-Xlinker", "-rpath", "-Xlinker", "/usr/lib/swift/linux",
+            "-Xlinker", "-rpath", "-Xlinker", "/${libdir}/swift/linux",
 
             "-Xlinker", "-L${STAGING_DIR_TARGET}",
-            "-Xlinker", "-L${STAGING_DIR_TARGET}/lib",
-            "-Xlinker", "-L${STAGING_DIR_TARGET}/usr/lib",
-            "-Xlinker", "-L${STAGING_DIR_TARGET}/usr/lib/swift/linux",
-            "-Xlinker", "-L${STAGING_DIR_TARGET}/usr/lib/${TARGET_SYS}/${SWIFT_GCC_VERSION}",
+            "-Xlinker", "-L${STAGING_DIR_TARGET}/${libdir}",
+            "-Xlinker", "-L${STAGING_DIR_TARGET}/${libdir}/swift/linux",
+            "-Xlinker", "-L${STAGING_DIR_TARGET}/${libdir}/${TARGET_SYS}/${SWIFT_GCC_VERSION}",
 
             "-Xlinker", "--build-id=sha1",
 
-            "-Xclang-linker", "-B${STAGING_DIR_TARGET}/usr/lib",
-            "-Xclang-linker", "-B${STAGING_DIR_TARGET}/usr/lib/${TARGET_SYS}/${SWIFT_GCC_VERSION}",
+            "-Xclang-linker", "-B${STAGING_DIR_TARGET}/${libdir}",
+            "-Xclang-linker", "-B${STAGING_DIR_TARGET}/${libdir}/${TARGET_SYS}/${SWIFT_GCC_VERSION}",
 
-            "-Xcc", "--gcc-install-dir=${STAGING_DIR_TARGET}/usr/lib/gcc/${TARGET_SYS}/${SWIFT_GCC_VERSION}",
+            "-Xcc", "--gcc-install-dir=${STAGING_DIR_TARGET}/${libdir}/gcc/${TARGET_SYS}/${SWIFT_GCC_VERSION}",
 
             ${SWIFT_EXTRA_SWIFTC_CC_FLAGS}
         ],
@@ -278,5 +277,13 @@ do_package_update() {
 }
 do_package_update[network] = "1"
 addtask do_package_update after do_configure
+
+python do_compile:prepend() {
+    bb.build.exec_func('swift_multilib_prepare_sysroot', d)
+}
+
+do_install:append() {
+    swift_multilib_install_fixup
+}
 
 EXPORT_FUNCTIONS do_configure do_compile do_package_update

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -1,6 +1,8 @@
 # We have a conf and classes directory, append to BBPATH
 BBPATH .= ":${LAYERDIR}"
 
+require conf/swift-multilib.conf
+
 # We have a recipes directory, add to BBFILES
 BBFILES += "${LAYERDIR}/recipes*/*/*.bb \
             ${LAYERDIR}/recipes*/*/*.bbappend"

--- a/conf/swift-multilib.conf
+++ b/conf/swift-multilib.conf
@@ -1,0 +1,3 @@
+# Swift is built for the 64-bit target only. When MULTILIBS includes lib32, skip
+# creating unsupported 32-bit variants of the Swift runtime and Foundation stack.
+NON_MULTILIB_RECIPES += "swift-stdlib swift-foundation swift-foundation-essentials swift-foundation-icu libdispatch swift-testing swift-xctest"

--- a/recipes-devtools/swift/libdispatch.bb
+++ b/recipes-devtools/swift/libdispatch.bb
@@ -17,7 +17,7 @@ LIBDISPATCH_BUILDDIR = "${UNPACKDIR}/build"
 
 inherit swift-cmake-base
 
-TARGET_LDFLAGS += "-L${STAGING_DIR_TARGET}/usr/lib/swift/linux"
+TARGET_LDFLAGS += "-L${STAGING_DIR_TARGET}/${libdir}/swift/linux"
 
 # Enable Swift parts
 EXTRA_OECMAKE += "-DENABLE_SWIFT=YES"

--- a/recipes-devtools/swift/swift-foundation-essentials.bb
+++ b/recipes-devtools/swift/swift-foundation-essentials.bb
@@ -11,10 +11,11 @@ SRCREV_FORMAT = "foundation_icu_syntax_collections"
 
 SRC_URI = "git://github.com/swiftlang/swift-foundation.git;protocol=https;name=foundation;tag=${SWIFT_TAG};nobranch=1;"
 SRC_URI += "git://github.com/swiftlang/swift-foundation-icu.git;protocol=https;name=icu;tag=${SWIFT_TAG};nobranch=1;destsuffix=swift-foundation-icu;"
-SRC_URI += "git://github.com/swiftlang/swift-syntax.git;protocol=https;name=syntax;tag=${SWIFT_TAG};nobranch=1;destsuffix=swift-foundation-icu;"
+SRC_URI += "git://github.com/swiftlang/swift-syntax.git;protocol=https;name=syntax;tag=${SWIFT_TAG};nobranch=1;destsuffix=swift-syntax;"
 SRC_URI += "git://github.com/apple/swift-collections.git;protocol=https;nobranch=1;name=collections;tag=1.1.6;destsuffix=swift-collections;"
 SRC_URI += "file://0001-build-with-64-bit-fsblkcnt_t-on-32-bit-glibc-platfor.patch;striplevel=1;"
 SRC_URI += "file://0002-build-with-64-bit-time_t-on-32-bit-platforms.patch;striplevel=1;"
+SRC_URI += "file://0003-use-local-swift-syntax-source-for-foundation-macros.patch;striplevel=1;"
 
 S = "${UNPACKDIR}/git"
 
@@ -23,7 +24,7 @@ RDEPENDS:${PN} += "icu swift-stdlib swift-foundation-icu"
 
 inherit swift-cmake-base
 
-TARGET_LDFLAGS += "-L${STAGING_DIR_TARGET}/usr/lib/swift/linux"
+TARGET_LDFLAGS += "-L${STAGING_DIR_TARGET}/${libdir}/swift/linux"
 
 # Enable Swift parts
 EXTRA_OECMAKE += "-DENABLE_SWIFT=YES"
@@ -32,7 +33,7 @@ EXTRA_OECMAKE += "-D_SwiftFoundationICU_SourceDIR=${UNPACKDIR}/swift-foundation-
 EXTRA_OECMAKE += "-D_SwiftCollections_SourceDIR=${UNPACKDIR}/swift-collections"
 EXTRA_OECMAKE += "-DSwiftFoundation_MODULE_TRIPLE=${SWIFT_TARGET_NAME}"
 EXTRA_OECMAKE += "-DSwiftCollections_MODULE_TRIPLE=${SWIFT_TARGET_NAME}"
-EXTRA_OECMAKE += "-DSwiftSyntax_DIR=${UNPACKDIR}/swift-syntax/cmake/modules"
+EXTRA_OECMAKE += "-D_SwiftSyntax_SourceDIR=${UNPACKDIR}/swift-syntax"
 
 # Ensure the right CPU is targeted
 cmake_do_generate_toolchain_file:append() {

--- a/recipes-devtools/swift/swift-foundation-essentials/0003-use-local-swift-syntax-source-for-foundation-macros.patch
+++ b/recipes-devtools/swift/swift-foundation-essentials/0003-use-local-swift-syntax-source-for-foundation-macros.patch
@@ -1,0 +1,41 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: William Page <williamtpage@gmail.com>
+Date: Mon, 1 Jun 2026 00:00:00 +0000
+Subject: [PATCH 3/3] use local swift-syntax source for Foundation macros
+
+Allow offline/Yocto builds to supply a pre-fetched swift-syntax checkout
+instead of relying on FetchContent to clone from GitHub.
+
+Upstream-Status: Submitted
+---
+ Sources/FoundationMacros/CMakeLists.txt | 14 +++++++++-----
+ 1 file changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/Sources/FoundationMacros/CMakeLists.txt b/Sources/FoundationMacros/CMakeLists.txt
+index 1111111..2222222 100644
+--- a/Sources/FoundationMacros/CMakeLists.txt
++++ b/Sources/FoundationMacros/CMakeLists.txt
+@@ -37,13 +37,18 @@ endif()
+ # SwiftSyntax Dependency
+ find_package(SwiftSyntax QUIET)
+ if(NOT SwiftSyntax_FOUND)
+-  message(STATUS "SwiftSyntax_DIR not provided, checking out local copy of swift-syntax")
+     include(FetchContent)
+ 
+-    # If building at desk, check out and link against the SwiftSyntax repo's targets
+-    FetchContent_Declare(SwiftSyntax
+-        GIT_REPOSITORY https://github.com/swiftlang/swift-syntax.git
+-        GIT_TAG main)
++    if(_SwiftSyntax_SourceDIR)
++        message(STATUS "_SwiftSyntax_SourceDIR provided, using swift-syntax checkout at ${_SwiftSyntax_SourceDIR}")
++        FetchContent_Declare(SwiftSyntax
++            SOURCE_DIR ${_SwiftSyntax_SourceDIR})
++    else()
++        message(STATUS "SwiftSyntax_DIR not provided, checking out local copy of swift-syntax")
++        FetchContent_Declare(SwiftSyntax
++            GIT_REPOSITORY https://github.com/swiftlang/swift-syntax.git
++            GIT_TAG main)
++    endif()
+     FetchContent_MakeAvailable(SwiftSyntax)
+ else()
+   message(STATUS "SwiftSyntax_DIR provided, using swift-syntax from ${SwiftSyntax_DIR}")

--- a/recipes-devtools/swift/swift-foundation-icu.bb
+++ b/recipes-devtools/swift/swift-foundation-icu.bb
@@ -17,7 +17,7 @@ RDEPENDS:${PN} += "swift-stdlib"
 
 inherit swift-cmake-base
 
-TARGET_LDFLAGS += "-L${STAGING_DIR_TARGET}/usr/lib/swift/linux"
+TARGET_LDFLAGS += "-L${STAGING_DIR_TARGET}/${libdir}/swift/linux"
 
 # Enable Swift parts
 EXTRA_OECMAKE += "-DENABLE_SWIFT=YES"

--- a/recipes-devtools/swift/swift-foundation.bb
+++ b/recipes-devtools/swift/swift-foundation.bb
@@ -23,9 +23,9 @@ RDEPENDS:${PN} += "swift-foundation-essentials swift-stdlib libdispatch"
 
 inherit swift-cmake-base
 
-TARGET_LDFLAGS += "-L${STAGING_DIR_TARGET}${libdir}/swift/linux"
+TARGET_LDFLAGS += "-L${STAGING_DIR_TARGET}/${libdir}/swift/linux"
 
-OECMAKE_C_FLAGS += "-I${STAGING_DIR_TARGET}${libdir}/swift"
+OECMAKE_C_FLAGS += "-I${STAGING_DIR_TARGET}/${libdir}/swift"
 
 EXTRA_OECMAKE += "-DENABLE_SWIFT=YES"
 EXTRA_OECMAKE += "-DCMAKE_VERBOSE_MAKEFILE=ON"
@@ -37,8 +37,8 @@ EXTRA_OECMAKE += "-DSwiftFoundation_MODULE_TRIPLE=${SWIFT_TARGET_NAME}"
 
 EXTRA_OECMAKE += "-DCMAKE_FIND_ROOT_PATH:PATH=${CROSS_COMPILE_DEPS_PATH}"
 
-EXTRA_OECMAKE += "-Ddispatch_DIR=${STAGING_DIR_TARGET}${libdir}/cmake/dispatch"
-EXTRA_OECMAKE += "-DSwiftSyntax_DIR=${STAGING_DIR_TARGET}${libdir}/cmake/dispatch"
+EXTRA_OECMAKE += "-Ddispatch_DIR=${STAGING_DIR_TARGET}/${libdir}/cmake/dispatch"
+EXTRA_OECMAKE += "-DSwiftSyntax_DIR=${STAGING_DIR_TARGET}/${libdir}/cmake/dispatch"
 EXTRA_OECMAKE += "-DENABLE_TESTING=0"
 EXTRA_OECMAKE += "-DBUILD_SHARED_LIBS=YES"
 EXTRA_OECMAKE += "-DDISPATCH_INCLUDE_PATH=${STAGING_DIR_TARGET}/${includedir}"

--- a/recipes-devtools/swift/swift-stdlib.bb
+++ b/recipes-devtools/swift/swift-stdlib.bb
@@ -27,11 +27,11 @@ DEPENDS = "gcc-runtime python3-native icu ncurses swift-native libgcc gcc glibc 
 
 inherit swift-cmake-base
 
-TARGET_LDFLAGS:append = " -w -fuse-ld=lld -L${STAGING_DIR_TARGET}/usr/lib/${TARGET_SYS}/${SWIFT_GCC_VERSION}"
+TARGET_LDFLAGS:append = " -w -fuse-ld=lld -L${STAGING_DIR_TARGET}/${libdir}/${TARGET_SYS}/${SWIFT_GCC_VERSION}"
 
 SWIFT_CMAKE_TOOLCHAIN_FILE = "${WORKDIR}/linux-${SWIFT_TARGET_ARCH}-toolchain.cmake"
 
-SWIFT_C_FLAGS = "${TARGET_CC_ARCH} -w -fuse-ld=lld -target ${SWIFT_TARGET_NAME} --sysroot ${STAGING_DIR_TARGET} -B${STAGING_DIR_TARGET}/usr/lib/${TARGET_SYS}/${SWIFT_GCC_VERSION} -L${STAGING_DIR_TARGET}/usr/lib/${TARGET_SYS}/${SWIFT_GCC_VERSION} -I${STAGING_DIR_TARGET}/usr/include ${EXTRA_INCLUDE_FLAGS}"
+SWIFT_C_FLAGS = "${TARGET_CC_ARCH} -w -fuse-ld=lld -target ${SWIFT_TARGET_NAME} --sysroot ${STAGING_DIR_TARGET} -B${STAGING_DIR_TARGET}/${libdir}/${TARGET_SYS}/${SWIFT_GCC_VERSION} -L${STAGING_DIR_TARGET}/${libdir}/${TARGET_SYS}/${SWIFT_GCC_VERSION} -I${STAGING_DIR_TARGET}/usr/include ${EXTRA_INCLUDE_FLAGS}"
 SWIFT_C_LINK_FLAGS = "${TARGET_LD_ARCH} -target ${SWIFT_TARGET_NAME} --sysroot ${STAGING_DIR_TARGET} ${EXTRA_INCLUDE_FLAGS}"
 
 SWIFT_CXX_FLAGS = "${SWIFT_C_FLAGS}"
@@ -41,8 +41,8 @@ SWIFT_CXX_LINK_FLAGS = "${SWIFT_C_LINK_FLAGS}"
 # one place, but Yocto splits them across usr/lib/<sys> and usr/lib/gcc/<sys>.
 # Copy the missing crt entries in additively (symlinks aren't followed here).
 do_fix_gcc_install_dir() {
-    src=${STAGING_DIR_TARGET}/usr/lib/${TARGET_SYS}/${SWIFT_GCC_VERSION}
-    dst=${STAGING_DIR_TARGET}/usr/lib/gcc/${TARGET_SYS}/${SWIFT_GCC_VERSION}
+    src=${STAGING_DIR_TARGET}/${libdir}/${TARGET_SYS}/${SWIFT_GCC_VERSION}
+    dst=${STAGING_DIR_TARGET}/${libdir}/gcc/${TARGET_SYS}/${SWIFT_GCC_VERSION}
     [ -d "${src}" ] || return 0
     mkdir -p "${dst}"
     for f in "${src}"/*; do
@@ -71,7 +71,7 @@ do_configure() {
     # Configure the llvm project to get the cmake files generated, so we can point
     # LLVM_DIR to this folder
     cmake -S ${LLVM_SRCDIR}/llvm -B ${LLVM_BUILDDIR} -G Ninja \
-       -DCMAKE_INSTALL_PREFIX=${STAGING_DIR_NATIVE}/usr/lib \
+       -DCMAKE_INSTALL_PREFIX=${STAGING_DIR_NATIVE}/${libdir_native} \
        -DCMAKE_C_COMPILER=${SWIFT_NATIVE_PATH}/clang \
        -DCMAKE_CXX_COMPILER=${SWIFT_NATIVE_PATH}/clang++ \
        -DLLVM_TARGETS_TO_BUILD="X86;ARM;AArch64" \
@@ -143,8 +143,8 @@ set(SWIFT_SDKS LINUX)
 set(SWIFT_SDK_LINUX_ARCH_${SWIFT_TARGET_ARCH}_PATH ${STAGING_DIR_TARGET})
 set(SWIFT_SDK_LINUX_ARCH_${SWIFT_TARGET_ARCH}_LIBC_INCLUDE_DIRECTORY ${STAGING_DIR_TARGET}/usr/include)
 set(SWIFT_SDK_LINUX_ARCH_${SWIFT_TARGET_ARCH}_LIBC_ARCHITECTURE_INCLUDE_DIRECTORY ${STAGING_DIR_TARGET}/usr/include)
-set(SWIFT_LINUX_${SWIFT_TARGET_ARCH}_ICU_I18N ${STAGING_DIR_TARGET}/usr/lib/libicui18n.so)
-set(SWIFT_LINUX_${SWIFT_TARGET_ARCH}_ICU_UC ${STAGING_DIR_TARGET}/usr/lib/libicuuc.so)
+set(SWIFT_LINUX_${SWIFT_TARGET_ARCH}_ICU_I18N ${STAGING_DIR_TARGET}/${libdir}/libicui18n.so)
+set(SWIFT_LINUX_${SWIFT_TARGET_ARCH}_ICU_UC ${STAGING_DIR_TARGET}/${libdir}/libicuuc.so)
 set(SWIFT_PATH_TO_LIBDISPATCH_SOURCE ${UNPACKDIR}/libdispatch)
 set(SWIFT_ENABLE_EXPERIMENTAL_CONCURRENCY ON)
 set(SWIFT_ENABLE_EXPERIMENTAL_CXX_INTEROP ON)
@@ -157,15 +157,15 @@ set(SWIFT_ENABLE_SYNCHRONIZATION ON)
 set(SWIFT_PATH_TO_STRING_PROCESSING_SOURCE ${UNPACKDIR}/swift-experimental-string-processing)
 set(SWIFT_SYNTAX_SOURCE_DIR ${UNPACKDIR}/swift-syntax)
 set(SWIFTSYNTAX_SOURCE_DIR ${UNPACKDIR}/swift-syntax)
-set(SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS -Xcc --gcc-install-dir=${STAGING_DIR_TARGET}/usr/lib/gcc/${TARGET_SYS}/${SWIFT_GCC_VERSION} -I${STAGING_DIR_TARGET}/usr/include/c++/${SWIFT_GCC_VERSION} -I${STAGING_DIR_TARGET}/usr/include/c++/${SWIFT_GCC_VERSION}/${TARGET_SYS} -no-verify-emitted-module-interface ${SWIFT_EXTRA_SWIFTC_CC_FLAGS})
+set(SWIFT_STANDARD_LIBRARY_SWIFT_FLAGS -Xcc --gcc-install-dir=${STAGING_DIR_TARGET}/${libdir}/gcc/${TARGET_SYS}/${SWIFT_GCC_VERSION} -I${STAGING_DIR_TARGET}/usr/include/c++/${SWIFT_GCC_VERSION} -I${STAGING_DIR_TARGET}/usr/include/c++/${SWIFT_GCC_VERSION}/${TARGET_SYS} -no-verify-emitted-module-interface ${SWIFT_EXTRA_SWIFTC_CC_FLAGS})
 set(SWIFT_SDK_LINUX_CXX_OVERLAY_SWIFT_COMPILE_FLAGS "")
 
-set(ICU_I18N_LIBRARIES ${STAGING_DIR_TARGET}/usr/lib/libicui18n.so)
+set(ICU_I18N_LIBRARIES ${STAGING_DIR_TARGET}/${libdir}/libicui18n.so)
 set(ICU_I18N_INCLUDE_DIRS ${STAGING_DIR_TARGET}/usr/include)
-set(ICU_UC_LIBRARIES ${STAGING_DIR_TARGET}/usr/lib/libicuuc.so)
+set(ICU_UC_LIBRARIES ${STAGING_DIR_TARGET}/${libdir}/libicuuc.so)
 set(ICU_UC_INCLUDE_DIRS ${STAGING_DIR_TARGET}/usr/include)
-set(LibRT_LIBRARIES ${STAGING_DIR_TARGET}/usr/lib/librt.a)
-set(ZLIB_LIBRARY ${STAGING_DIR_TARGET}/usr/lib/libz.so)
+set(LibRT_LIBRARIES ${STAGING_DIR_TARGET}/${libdir}/librt.a)
+set(ZLIB_LIBRARY ${STAGING_DIR_TARGET}/${libdir}/libz.so)
 EOF
 
     # pthreads does not work with armv7, so use c11 threading package in lieu

--- a/recipes-devtools/swift/swift-xctest.bb
+++ b/recipes-devtools/swift/swift-xctest.bb
@@ -17,7 +17,7 @@ B = "${WORKDIR}/build"
 
 inherit swift
 
-TARGET_LDFLAGS += "-L${STAGING_DIR_TARGET}/usr/lib/swift/linux"
+TARGET_LDFLAGS += "-L${STAGING_DIR_TARGET}/${libdir}/swift/linux"
 
 do_install() {
     install -d ${D}${libdir}/swift/linux


### PR DESCRIPTION
We have an aarch64 target that needs to also install and execute some armv7a code. This mostly doesn't affect swift except for one thing - enabling multilib changes the native (aarch64) lib dir from /usr/lib to /usr/lib64.

For recipes that can tell the source build system what to use as libdir for build and install, this all works fine - everything gets setup to use /usr/lib for normal builds and /usr/lib64 for the native arch during multilib builds.

So when building swift packages (swift.bbclass), we need to fixup the sysroot because swift/cmake really want to use /usr/lib/swift, even though things are in /usr/lib64/swift, so we fixup the sysroot so that it can find what it's looking for in /usr/lib via symlink. During install, we fixup things that landed in /usr/lib so that they end up in ${libdir} (in the multilib case, /usr/lib64).

Nothing here is meant to enable or support building/install 32-bit swift on a 64-bit device.  This is only to support building and installing 64-bit swift on a 64-bit device that happens to also support 32-bit binaries.