### PR TITLE
swift-stdlib: align Swift module triple with Yocto TARGET_SYS

### DIFF
--- a/classes/swift-common.bbclass
+++ b/classes/swift-common.bbclass
@@ -28,7 +28,9 @@ SWIFT_CLANG_VERSION = "21"
 # switch that also rebuilds compiler-rt/libunwind/libgcc).
 SWIFT_CXX_RUNTIME ?= "gnu"
 
-SWIFT_TARGET_NAME = "${@oe.utils.conditional('TARGET_ARCH', 'arm', 'armv7-unknown-linux-gnueabihf', '${TARGET_ARCH}-unknown-linux-gnu', d)}"
+# Use Yocto's TARGET_SYS instead of the upstream Swift triple, so swiftc -target,
+# .swiftinterface module names and clang's per-triple header lookup all agree.
+SWIFT_TARGET_NAME = "${TARGET_SYS}"
 SWIFT_TARGET_ARCH = "${@oe.utils.conditional('TARGET_ARCH', 'arm', 'armv7', '${TARGET_ARCH}', d)}"
 TARGET_CPU_NAME = "${@oe.utils.conditional('TARGET_ARCH', 'arm', 'armv7-a', '${TARGET_ARCH}', d)}"
 

--- a/recipes-devtools/swift/swift-stdlib.bb
+++ b/recipes-devtools/swift/swift-stdlib.bb
@@ -19,6 +19,7 @@ SRC_URI = "\
     git://github.com/swiftlang/swift-syntax.git;protocol=https;name=syntax;tag=${SWIFT_TAG};nobranch=1;destsuffix=swift-syntax; \
     file://0003-add-fix-for-metadataaccessor-abi-mismatch.patch;striplevel=1; \
     file://0004-AddSwiftStdlib-skip-empty-sysroot-injection.patch;striplevel=1; \
+    file://0005-allow-overriding-SWIFT_SDK_LINUX_ARCH_TRIPLE.patch;striplevel=1; \
     "
 
 S = "${UNPACKDIR}/swift"
@@ -178,6 +179,7 @@ set(SWIFT_RUNTIME_OS_VERSIONING OFF)
 set(SWIFT_HOST_VARIANT_ARCH ${SWIFT_TARGET_ARCH})
 set(SWIFT_SDKS LINUX)
 set(SWIFT_SDK_LINUX_ARCH_${SWIFT_TARGET_ARCH}_PATH ${STAGING_DIR_TARGET})
+set(SWIFT_SDK_LINUX_ARCH_${SWIFT_TARGET_ARCH}_TRIPLE ${SWIFT_TARGET_NAME})
 set(SWIFT_SDK_LINUX_ARCH_${SWIFT_TARGET_ARCH}_LIBC_INCLUDE_DIRECTORY ${STAGING_DIR_TARGET}/usr/include)
 set(SWIFT_SDK_LINUX_ARCH_${SWIFT_TARGET_ARCH}_LIBC_ARCHITECTURE_INCLUDE_DIRECTORY ${STAGING_DIR_TARGET}/usr/include)
 set(SWIFT_LINUX_${SWIFT_TARGET_ARCH}_ICU_I18N ${STAGING_DIR_TARGET}/usr/lib/libicui18n.so)

--- a/recipes-devtools/swift/swift-stdlib/0005-allow-overriding-SWIFT_SDK_LINUX_ARCH_TRIPLE.patch
+++ b/recipes-devtools/swift/swift-stdlib/0005-allow-overriding-SWIFT_SDK_LINUX_ARCH_TRIPLE.patch
@@ -1,0 +1,33 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Nikolas Zimmermann <nzimmermann@igalia.com>
+Date: Thu, 28 May 2026 00:00:00 +0000
+Subject: [PATCH] Allow overriding SWIFT_SDK_LINUX_ARCH_<arch>_TRIPLE
+
+Guard the per-arch defaults with if(NOT DEFINED) so meta-swift can supply
+a Yocto-aligned triple (e.g. aarch64-poky-linux) from the toolchain file;
+otherwise the stdlib emits modules named with the upstream triple and
+consumers built with -target <vendor-triple> can't find them.
+
+Upstream-Status: Pending
+Signed-off-by: Nikolas Zimmermann <nzimmermann@igalia.com>
+---
+diff --git a/cmake/modules/SwiftConfigureSDK.cmake b/cmake/modules/SwiftConfigureSDK.cmake
+--- a/cmake/modules/SwiftConfigureSDK.cmake
++++ b/cmake/modules/SwiftConfigureSDK.cmake
+@@ -422,7 +422,13 @@
+         if(arch MATCHES "(armv5)")
+-          set(SWIFT_SDK_LINUX_ARCH_${arch}_TRIPLE "${arch}-unknown-linux-gnueabi")
++          if(NOT DEFINED SWIFT_SDK_LINUX_ARCH_${arch}_TRIPLE)
++            set(SWIFT_SDK_LINUX_ARCH_${arch}_TRIPLE "${arch}-unknown-linux-gnueabi")
++          endif()
+         elseif(arch MATCHES "(armv6|armv7)")
+-          set(SWIFT_SDK_LINUX_ARCH_${arch}_TRIPLE "${arch}-unknown-linux-gnueabihf")
++          if(NOT DEFINED SWIFT_SDK_LINUX_ARCH_${arch}_TRIPLE)
++            set(SWIFT_SDK_LINUX_ARCH_${arch}_TRIPLE "${arch}-unknown-linux-gnueabihf")
++          endif()
+         elseif(arch MATCHES "(aarch64|i686|powerpc|powerpc64|powerpc64le|s390x|x86_64|riscv64)")
+-          set(SWIFT_SDK_LINUX_ARCH_${arch}_TRIPLE "${arch}-unknown-linux-gnu")
++          if(NOT DEFINED SWIFT_SDK_LINUX_ARCH_${arch}_TRIPLE)
++            set(SWIFT_SDK_LINUX_ARCH_${arch}_TRIPLE "${arch}-unknown-linux-gnu")
++          endif()
+         else()


### PR DESCRIPTION
Yocto builds with -target ${TARGET_SYS} (e.g. aarch64-poky-linux), but the Swift stdlib emitted its .swiftinterface modules under the hard-coded upstream triple (aarch64-unknown-linux-gnu). Consumers compiled with the Yocto triple then fail to find the modules.

Set SWIFT_TARGET_NAME to TARGET_SYS so swiftc -target, the .swiftinterface module names and clang's per-triple header lookup all agree, and pass the matching SWIFT_SDK_LINUX_ARCH_<arch>_TRIPLE into the stdlib build.

The upstream cmake unconditionally hard-codes the per-arch triple, so add 0005-allow-overriding-SWIFT_SDK_LINUX_ARCH_TRIPLE.patch to guard the defaults with if(NOT DEFINED), letting the recipe override it.

* classes/swift-common.bbclass: SWIFT_TARGET_NAME = TARGET_SYS.
* recipes-devtools/swift/swift-stdlib.bb: add the patch to SRC_URI and set the per-arch TRIPLE to SWIFT_TARGET_NAME.
* recipes-devtools/swift/swift-stdlib/0005-allow-overriding-SWIFT_SDK_LINUX_ARCH_TRIPLE.patch: new.