### PR TITLE
swift-stdlib: copy gcc crt files additively in do_fix_gcc_install_dir

### DIFF
--- a/recipes-devtools/swift/swift-stdlib.bb
+++ b/recipes-devtools/swift/swift-stdlib.bb
@@ -82,10 +82,18 @@ SWIFT_STDLIB_CXX_FLAGS = "${@bb.utils.contains('SWIFT_CXX_RUNTIME', 'llvm', \
     '-Xcc -stdlib=libc++ -Xcc -I${STAGING_DIR_TARGET}/usr/include/c++/v1', \
     '-I${STAGING_DIR_TARGET}/usr/include/c++/${SWIFT_GCC_VERSION} -I${STAGING_DIR_TARGET}/usr/include/c++/${SWIFT_GCC_VERSION}/${TARGET_SYS}', d)}"
 
+# clang's libstdc++ heuristic wants crt*.o and the gcc-internal include dirs in
+# one place, but Yocto splits them across usr/lib/<sys> and usr/lib/gcc/<sys>.
+# Copy the missing crt entries in additively (symlinks aren't followed here).
 do_fix_gcc_install_dir() {
-    # symbolic links do not work, will not be found by Swift clang driver
-    # this is necessary to make the libstdc++ location heuristic work, necessary for C++ interop
-    (cd ${STAGING_DIR_TARGET}/usr/lib && rm -rf gcc && mkdir -p gcc && cp -rp ${TARGET_ARCH}${TARGET_VENDOR}-${TARGET_OS} gcc)
+    src=${STAGING_DIR_TARGET}/usr/lib/${TARGET_SYS}/${SWIFT_GCC_VERSION}
+    dst=${STAGING_DIR_TARGET}/usr/lib/gcc/${TARGET_SYS}/${SWIFT_GCC_VERSION}
+    [ -d "${src}" ] || return 0
+    mkdir -p "${dst}"
+    for f in "${src}"/*; do
+        bn=$(basename "${f}")
+        [ -e "${dst}/${bn}" ] || cp -rp "${f}" "${dst}/${bn}"
+    done
 }
 
 addtask fix_gcc_install_dir before do_configure after do_prepare_recipe_sysroot


### PR DESCRIPTION
clang's libstdc++ location heuristic expects the crt*.o files and the gcc-internal include dirs to live together under usr/lib/gcc/<sys>/<ver>, but Yocto splits them between usr/lib/<sys>/<ver> and usr/lib/gcc/<sys>/<ver>.

The previous implementation removed usr/lib/gcc entirely and recreated it as a copy of usr/lib/<arch><vendor>-<os>. That clobbered whatever the gcc recipe had already staged under usr/lib/gcc and relied on the <arch><vendor>-<os> spelling rather than TARGET_SYS.

Instead, copy only the crt entries that are missing from the gcc-internal dir, preserving everything already there. Real copies (not symlinks) are required: the Swift clang driver does not follow symlinks for this lookup.

* recipes-devtools/swift/swift-stdlib.bb: