### PR TITLE
swift: run git's ssh transport with a clean LD_LIBRARY_PATH

### DIFF
--- a/classes/swift.bbclass
+++ b/classes/swift.bbclass
@@ -22,6 +22,13 @@ BUILD_DIR = "${B}/${BUILD_MODE}"
 # Additional parameters to pass to SPM
 EXTRA_OESWIFT ?= ""
 
+# We prepend the native sysroot lib dir to LD_LIBRARY_PATH so swiftpm picks up
+# the native libcurl (issue #42), but that leaks into the host ssh binary that
+# git uses for ssh:// dependencies, which then loads the native libcrypto and
+# aborts with an OpenSSL ABI mismatch (issue #71). Run that ssh child with a
+# clean LD_LIBRARY_PATH so it uses the host's own libcrypto.
+SWIFT_GIT_SSH_COMMAND ?= "env -u LD_LIBRARY_PATH ssh"
+
 do_fix_gcc_install_dir() {
     # symbolic links do not work, will not be found by Swift clang driver
     # this is necessary to make the libstdc++ location heuristic work, necessary for C++ interop
@@ -77,6 +84,9 @@ python do_swift_package_resolve() {
     if env.get('LD_LIBRARY_PATH'):
         ld_path += ':' + env['LD_LIBRARY_PATH']
     env['LD_LIBRARY_PATH'] = ld_path
+
+    # Don't leak the native libcrypto above into git's ssh transport (issue #71).
+    env.setdefault('GIT_SSH_COMMAND', d.getVar('SWIFT_GIT_SSH_COMMAND'))
 
     ssh_auth_sock = d.getVar('BB_ORIGENV').get('SSH_AUTH_SOCK')
     if ssh_auth_sock:
@@ -362,6 +372,9 @@ python swift_do_compile() {
     if env.get('LD_LIBRARY_PATH'):
         ld_path += ':' + env['LD_LIBRARY_PATH']
     env['LD_LIBRARY_PATH'] = ld_path
+
+    # Don't leak the native libcrypto above into git's ssh transport (issue #71).
+    env.setdefault('GIT_SSH_COMMAND', d.getVar('SWIFT_GIT_SSH_COMMAND'))
 
     if ssh_auth_sock:
         env['SSH_AUTH_SOCK'] = ssh_auth_sock


### PR DESCRIPTION
Fixes #71.

## Problem
Commit 122ae99 prepends the native sysroot lib dir to `LD_LIBRARY_PATH` in `do_swift_package_resolve` and `swift_do_compile` so swiftpm's `libFoundationNetworking` picks up the native `libcurl.so.4` (#42). That environment is inherited by the `git` invocations swiftpm spawns and, in turn, by the host `ssh` binary git uses for `ssh://` (`git@…`) dependencies. The host `ssh` is linked against the host OpenSSL (3.0.x → `30000020`) but ends up loading the **native** Scarthgap `libcrypto.so.3` (3.5.5 → `30500050`), and libcrypto's runtime ABI guard aborts:

```
Fetching origin
OpenSSL version mismatch. Built against 30000020, you have 30500050
fatal: Could not read from remote repository.
```

## Fix
Set `GIT_SSH_COMMAND` to run `ssh` with a clean `LD_LIBRARY_PATH` in **both** functions (the resolve task is where most dependency fetching happens, so a `do_compile`-only fix would miss it). swiftpm itself keeps the native `libcurl`; only the standalone `ssh` child is given back the host's own `libcrypto`.

- Overridable via `SWIFT_GIT_SSH_COMMAND` (default `env -u LD_LIBRARY_PATH ssh`).
- Respects a user-provided `GIT_SSH_COMMAND` via `env.setdefault`.

git's https transport is unaffected — it uses the native `libcurl`/`libssl` together, which are self-consistent.

## Credit
Root-cause diagnosis and the working `GIT_SSH_COMMAND` approach are from @TaborKelly in #71; this PR folds it into the class, applies it to both functions, and makes it overridable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)