### PR TITLE
swift-stdlib: use an armv7 hard-float triple on 32-bit arm

### DIFF
--- a/classes/swift-common.bbclass
+++ b/classes/swift-common.bbclass
@@ -21,7 +21,23 @@ python () {
 
 SWIFT_CLANG_VERSION = "21"
 
-SWIFT_TARGET_NAME = "${@oe.utils.conditional('TARGET_ARCH', 'arm', 'armv7-unknown-linux-gnueabihf', '${TARGET_ARCH}-unknown-linux-gnu', d)}"
+# Use Yocto's TARGET_SYS instead of the upstream Swift triple, so swiftc -target,
+# .swiftinterface module names and clang's per-triple header lookup all agree.
+#
+# On 32-bit arm, TARGET_SYS is e.g. arm-oe-linux-gnueabi, which is wrong for
+# swiftc's -target in two ways. First, the bare "arm" arch token isn't a
+# platform swiftc recognises, so it warns "unknown platform, assuming
+# -mfloat-abi=soft" and looks for the per-arch SwiftGlibc modulemap under an
+# "arm" dir while the stdlib stages it under "armv7" (SWIFT_TARGET_ARCH), so the
+# build dies with "error: no such module 'SwiftGlibc'". Second, Yocto keeps the
+# float ABI out of the triple and conveys hard-float via -mfloat-abi=hard in
+# TARGET_CC_ARCH. Those flags only reach the Clang importer via -Xcc, but
+# swiftc's own codegen takes the float ABI from the triple, so a gnueabi triple
+# is soft-float against a hard-float (cortexa15t2hf) sysroot. Promote the arch
+# token to armv7 and append the "hf" environment suffix, keeping Yocto's
+# vendor/os so .swiftinterface module names still agree. aarch64 and x86_64 have
+# no such ambiguity and use TARGET_SYS verbatim.
+SWIFT_TARGET_NAME = "${@oe.utils.conditional('TARGET_ARCH', 'arm', d.getVar('TARGET_SYS').replace('arm-', 'armv7-', 1) + 'hf', '${TARGET_SYS}', d)}"
 SWIFT_TARGET_ARCH = "${@oe.utils.conditional('TARGET_ARCH', 'arm', 'armv7', '${TARGET_ARCH}', d)}"
 TARGET_CPU_NAME = "${@oe.utils.conditional('TARGET_ARCH', 'arm', 'armv7-a', '${TARGET_ARCH}', d)}"
 


### PR DESCRIPTION
Commit 6353268 set SWIFT_TARGET_NAME to TARGET_SYS, which on arm is arm-oe-linux-gnueabi. swiftc cannot use that triple as-is. It does not know the bare "arm" arch, so it fails to find the SwiftGlibc modulemap that the stdlib stages under "armv7", and it reads soft-float from the gnueabi triple while the sysroot is hard-float. The swift-stdlib build then fails with "error: no such module 'SwiftGlibc'"....

Rewrite the arm triple to armv7-...-gnueabihf, keeping the Yocto vendor and OS so the .swiftinterface module names still match. aarch64 and x86_64 carry no such ambiguity and keep using TARGET_SYS as-is.

* classes/swift-common.bbclass: derive an armv7 hard-float triple on arm.