### PR TITLE
swift-common: give non-arm Linux triples an explicit -gnu environment

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,9 +19,9 @@ jobs:
           sudo apt install -y build-essential chrpath cpio debianutils diffstat file gawk gcc git iputils-ping libacl1 liblz4-tool locales python3 python3-git python3-jinja2 python3-pexpect python3-pip python3-subunit socat texinfo unzip wget xz-utils zstd qemu-user
           echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
       - name: Checkout BitBake
-        run: git clone --depth 1 --branch master https://git.openembedded.org/bitbake $GITHUB_WORKSPACE/bitbake
+        run: git clone --depth 1 --branch 2.18 https://git.openembedded.org/bitbake $GITHUB_WORKSPACE/bitbake
       - name: Checkout OpenEmbedded Core
-        run: git clone --depth 1 --branch master https://git.openembedded.org/openembedded-core $GITHUB_WORKSPACE/openembedded-core
+        run: git clone --depth 1 --branch wrynose https://git.openembedded.org/openembedded-core $GITHUB_WORKSPACE/openembedded-core
       - name: Checkout Swift layer
         uses: actions/checkout@v4
         with:
@@ -53,9 +53,9 @@ jobs:
           sudo apt install -y build-essential chrpath cpio debianutils diffstat file gawk gcc git iputils-ping libacl1 liblz4-tool locales python3 python3-git python3-jinja2 python3-pexpect python3-pip python3-subunit socat texinfo unzip wget xz-utils zstd qemu-user
           echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
       - name: Checkout BitBake
-        run: git clone --depth 1 --branch master https://git.openembedded.org/bitbake $GITHUB_WORKSPACE/bitbake
+        run: git clone --depth 1 --branch 2.18 https://git.openembedded.org/bitbake $GITHUB_WORKSPACE/bitbake
       - name: Checkout OpenEmbedded Core
-        run: git clone --depth 1 --branch master https://git.openembedded.org/openembedded-core $GITHUB_WORKSPACE/openembedded-core
+        run: git clone --depth 1 --branch wrynose https://git.openembedded.org/openembedded-core $GITHUB_WORKSPACE/openembedded-core
       - name: Checkout Swift layer
         uses: actions/checkout@v4
         with:
@@ -87,9 +87,9 @@ jobs:
           sudo apt install -y build-essential chrpath cpio debianutils diffstat file gawk gcc git iputils-ping libacl1 liblz4-tool locales python3 python3-git python3-jinja2 python3-pexpect python3-pip python3-subunit socat texinfo unzip wget xz-utils zstd qemu-user
           echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
       - name: Checkout BitBake
-        run: git clone --depth 1 --branch master https://git.openembedded.org/bitbake $GITHUB_WORKSPACE/bitbake
+        run: git clone --depth 1 --branch 2.18 https://git.openembedded.org/bitbake $GITHUB_WORKSPACE/bitbake
       - name: Checkout OpenEmbedded Core
-        run: git clone --depth 1 --branch master https://git.openembedded.org/openembedded-core $GITHUB_WORKSPACE/openembedded-core
+        run: git clone --depth 1 --branch wrynose https://git.openembedded.org/openembedded-core $GITHUB_WORKSPACE/openembedded-core
       - name: Checkout Swift layer
         uses: actions/checkout@v4
         with:

--- a/classes/swift-common.bbclass
+++ b/classes/swift-common.bbclass
@@ -42,9 +42,32 @@ SWIFT_CXX_RUNTIME ?= "gnu"
 # swiftc's own codegen takes the float ABI from the triple, so a gnueabi triple
 # is soft-float against a hard-float (cortexa15t2hf) sysroot. Promote the arch
 # token to armv7 and append the "hf" environment suffix, keeping Yocto's
-# vendor/os so .swiftinterface module names still agree. aarch64 and x86_64 have
-# no such ambiguity and use TARGET_SYS verbatim.
-SWIFT_TARGET_NAME = "${@oe.utils.conditional('TARGET_ARCH', 'arm', d.getVar('TARGET_SYS').replace('arm-', 'armv7-', 1) + 'hf', '${TARGET_SYS}', d)}"
+# vendor/os so .swiftinterface module names still agree.
+#
+# Non-arm triples additionally gain an explicit "-gnu" environment when Yocto's
+# TARGET_OS is bare "linux" (i.e. glibc): Swift Build's platform registry
+# refuses environment-less Linux triples outright --
+#     unable to find a single platform name for triple 'aarch64-oe-linux'
+# -- while accepting aarch64-oe-linux-gnu (the "oe" vendor is fine; only the
+# missing environment matters). llbuild doesn't care either way, and clang and
+# swiftc treat the two spellings identically, so this is harmless under the
+# native build system and a hard prerequisite for ever adopting swiftbuild.
+# armv7 already carries "hf" (gnueabihf) via the branch above, and musl
+# targets already have "-musl" in TARGET_SYS, so only bare-"linux" needs it.
+#
+# NB SWIFT_TARGET_NAME is also the *_MODULE_TRIPLE for every runtime recipe:
+# changing it renames the staged swiftmodule dirs (aarch64-oe-linux.swiftmodule
+# -> aarch64-oe-linux-gnu.swiftmodule), so the Swift runtime rebuilds once on
+# upgrade past this commit.
+def swift_target_name(d):
+    ts = d.getVar('TARGET_SYS')
+    if d.getVar('TARGET_ARCH') == 'arm':
+        return ts.replace('arm-', 'armv7-', 1) + 'hf'
+    if d.getVar('TARGET_OS') == 'linux':
+        return ts + '-gnu'
+    return ts
+
+SWIFT_TARGET_NAME = "${@swift_target_name(d)}"
 SWIFT_TARGET_ARCH = "${@oe.utils.conditional('TARGET_ARCH', 'arm', 'armv7', '${TARGET_ARCH}', d)}"
 TARGET_CPU_NAME = "${@oe.utils.conditional('TARGET_ARCH', 'arm', 'armv7-a', '${TARGET_ARCH}', d)}"
 


### PR DESCRIPTION
Yocto's glibc `TARGET_SYS` has no environment component on aarch64/x86_64 (`aarch64-oe-linux`), and `SWIFT_TARGET_NAME` used it verbatim. Swift's guidance (via Max Desiatov) is that target triples should always carry the environment component — Swift Build now enforces it, and swift-sdk-generator is expected to enforce a `-gnu`/`-musl` suffix as well. Without it, every SwiftPM recipe under the swiftbuild engine fails immediately:

```
error: unable to find a single platform name for triple 'aarch64-oe-linux'. results: []
```

The `oe` vendor is fine; only the missing environment matters (see the isolation table in the #76 investigation comment). llbuild doesn't care either way, and clang/swiftc treat both spellings identically — so this is harmless under the `native` build system we pin today, and a hard prerequisite for ever adopting `swiftbuild`.

## Change

Append `-gnu` whenever `TARGET_OS` is bare `linux` (i.e. glibc). armv7 already carries `hf` → `gnueabihf` via the existing branch; musl targets already have `-musl` in `TARGET_SYS`.

| MACHINE | before | after |
|---|---|---|
| qemux86-64 | `x86_64-oe-linux` | `x86_64-oe-linux-gnu` |
| qemuarm64 | `aarch64-oe-linux` | `aarch64-oe-linux-gnu` |
| qemuarm | `armv7-oe-linux-gnueabihf` | unchanged |

## Impact

`SWIFT_TARGET_NAME` is also the `*_MODULE_TRIPLE` for every runtime recipe, so the staged swiftmodule directories are renamed (`aarch64-oe-linux.swiftmodule` → `aarch64-oe-linux-gnu.swiftmodule`) and **the Swift runtime rebuilds once** on upgrade past this commit. Mixing old modules with the new triple fails with `could not find module 'Swift' for target 'aarch64-oe-linux-gnu'` until the rebuild completes — sstate handles this automatically; only pre-populated SDKs/sysrooots assembled outside bitbake would need care.

Validated on a real aarch64 downstream (cortexa72, `SWIFT_CXX_RUNTIME = "llvm"`): the runtime rebuilds cleanly with the new triple and SwiftPM recipes build and link against the renamed modules.

## Relationship to other PRs

Intended to land **first**, with #76 (6.4) and #58 (source-built toolchain) rebasing onto it — both currently construct triples through the same seam, so the rebase is mechanical.
